### PR TITLE
Fixed a typo

### DIFF
--- a/AIND-Simulated_Annealing.ipynb
+++ b/AIND-Simulated_Annealing.ipynb
@@ -233,7 +233,7 @@
     "        -------\n",
     "        float\n",
     "            A floating point value with the total cost of the path given by visiting\n",
-    "            the cities in the order according to the self.cities list\n",
+    "            the cities in the order according to the self.path list\n",
     "        \n",
     "        Notes\n",
     "        -----\n",


### PR DESCRIPTION
Fixed a typo in the docstring of `TravelingSalesmanProblem.get_value()` incorrectly referring to `self.path` as `self.cities`.